### PR TITLE
Regeleinden aslabels naar functie & optie witregels toevoegen voor uitlijning grafieken

### DIFF
--- a/hulpfuncties.R
+++ b/hulpfuncties.R
@@ -1414,7 +1414,8 @@ maak_staafdiagram_meerdere_staven <- function(data, var_inhoud, var_crossing = N
                                               niveaus = "regio",
                                               var_inhoud_waarde = NULL,
                                               tabel_en_grafiek = FALSE,
-                                              toon_y = FALSE
+                                              toon_y = FALSE,
+                                              toon_aslabel = TRUE
                                               ){
   
   #Keuzes die we gebruikers willen bieden mbt niveau:
@@ -1669,6 +1670,11 @@ maak_staafdiagram_meerdere_staven <- function(data, var_inhoud, var_crossing = N
           plot.caption = element_text(size = caption_size)
     )
   
+  
+  #Aslabel verwijderen als als dat is aangegeven.
+  if(!toon_aslabel){
+    plot <- plot +  theme(axis.text = element_blank()) 
+  }
   
   #toon y: laat Y as zien met rechte lijn + ticklabels
   if(toon_y){

--- a/voorbeeld_rapportage.qmd
+++ b/voorbeeld_rapportage.qmd
@@ -803,10 +803,10 @@ plot = monitor_df %>%
     var_inhoud = "LVSTA415",
     var_inhoud_waarde = 1,
     titel = "Voelt zich (heel) vaak gestrest",
-    niveaus = c("gemeente", "regio")
-  ) +
-  theme(axis.text = element_blank())  #Om te zorgen dat deze grafiek mooi uitlijnt met staafdiagram_vergelijking hiernaast verwijderen we het as-label 
-  #ggplot theme: https://ggplot2.tidyverse.org/reference/theme.html
+    niveaus = c("gemeente", "regio"),
+    toon_aslabel = FALSE  #Om te zorgen dat deze grafiek mooi uitlijnt met staafdiagram_vergelijking hiernaast verwijderen we het as-label 
+  )
+
 
 plot
 


### PR DESCRIPTION
Aslabels moeten niet in elkaar overlopen. In grafiekfuncties argumenten toegevoegd:

- **x_als_label_wrap:** aantal characters waarna een regeleinde ("\n") wordt ingevoegd in de labels op de X-as. Standaard afh. van grafiektype en of flip = TRUE
- **x_as_regels_toevoegen**: aantal witregels dat wordt toegevoegd onder x-as labels. Standaard 0. Nut van argument is om de X-as-lijn van twee grafieken die naast elkaar staan uit te lijnen wanneer het regelaantal van de aslabels verschilt.
